### PR TITLE
Typo: ships -> shims

### DIFF
--- a/docs/Gems,-Eggs-and-Perl-Modules.md
+++ b/docs/Gems,-Eggs-and-Perl-Modules.md
@@ -62,7 +62,7 @@ following content:
 
 ### Using virtualenv - works with brewed and system’s Python
 
-[Virtualenv](http://www.virtualenv.org/en/latest/) ships `pip` and
+[Virtualenv](http://www.virtualenv.org/en/latest/) shims `pip` and
 creates isolated Python environments with separate site-packages,
 therefore you won’t need sudo.
 


### PR DESCRIPTION
Virtualenv does not ship its own pip.  It *does* goof around with the environment so that pip behaves the way that it want it to, so I think that **shim** is the word that the author was looking for.

I'm skipping the various checkboxes since this is a one-character typo fix.
